### PR TITLE
Create Check-In List View and Grey Container

### DIFF
--- a/Routine-Machine/lib/CheckInItem.dart
+++ b/Routine-Machine/lib/CheckInItem.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class CheckInItem extends StatelessWidget {
+  final int color;
+  String checkInTime;
+  CheckInItem({checkInTime, this.color}) {
+    this.checkInTime = DateFormat('EE, MMMM d').add_jm().format(checkInTime);
+  }
+  @override
+  Widget build(BuildContext context) {
+    return RichText(
+      text: TextSpan(
+        style: TextStyle(
+          fontSize: 18.0,
+          color: Colors.black,
+          height: 1.5,
+        ),
+        children: [
+          TextSpan(
+            text: '\u2022 ',
+            style: TextStyle(
+              color: Color(this.color),
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          TextSpan(
+            text: 'Check-in on $checkInTime',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/Routine-Machine/lib/CheckInList.dart
+++ b/Routine-Machine/lib/CheckInList.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import './GreyContainer.dart';
+
+class CheckInItem extends StatelessWidget {
+  String checkInTime;
+  CheckInItem({checkInTime}) {
+    this.checkInTime = DateFormat().add_MEd().add_jm().format(checkInTime);
+  }
+  @override
+  Widget build(BuildContext context) {
+    return RichText(
+      text: TextSpan(
+        style: TextStyle(
+          fontSize: 18.0,
+          color: Colors.black,
+          height: 1.5,
+        ),
+        children: [
+          TextSpan(
+            text: '\u2022 ',
+            style: TextStyle(
+              color: Colors.blue,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          TextSpan(
+            text: 'Check-in on $checkInTime',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class CheckInList extends StatelessWidget {
+  final List<DateTime> checkIns;
+
+  CheckInList({this.checkIns});
+
+  @override
+  Widget build(BuildContext context) {
+    return GreyContainer(
+      child: ListView(
+        padding: EdgeInsets.all(16),
+        shrinkWrap: true,
+        children:
+            checkIns.map((time) => CheckInItem(checkInTime: time)).toList(),
+      ),
+    );
+  }
+}

--- a/Routine-Machine/lib/CheckInList.dart
+++ b/Routine-Machine/lib/CheckInList.dart
@@ -1,43 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
-
+import './CheckInItem.dart';
 import './GreyContainer.dart';
-
-class CheckInItem extends StatelessWidget {
-  String checkInTime;
-  CheckInItem({checkInTime}) {
-    this.checkInTime = DateFormat().add_MEd().add_jm().format(checkInTime);
-  }
-  @override
-  Widget build(BuildContext context) {
-    return RichText(
-      text: TextSpan(
-        style: TextStyle(
-          fontSize: 18.0,
-          color: Colors.black,
-          height: 1.5,
-        ),
-        children: [
-          TextSpan(
-            text: '\u2022 ',
-            style: TextStyle(
-              color: Colors.blue,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          TextSpan(
-            text: 'Check-in on $checkInTime',
-          ),
-        ],
-      ),
-    );
-  }
-}
 
 class CheckInList extends StatelessWidget {
   final List<DateTime> checkIns;
+  final int color;
 
-  CheckInList({this.checkIns});
+  CheckInList({this.checkIns, this.color});
 
   @override
   Widget build(BuildContext context) {
@@ -45,8 +14,13 @@ class CheckInList extends StatelessWidget {
       child: ListView(
         padding: EdgeInsets.all(16),
         shrinkWrap: true,
-        children:
-            checkIns.map((time) => CheckInItem(checkInTime: time)).toList(),
+        children: checkIns.isEmpty
+            // if no check ins, show this default message text
+            ? [Text('No recent activity', style: TextStyle(fontSize: 18.0))]
+            : checkIns
+                .map(
+                    (time) => CheckInItem(checkInTime: time, color: this.color))
+                .toList(),
       ),
     );
   }

--- a/Routine-Machine/lib/GreyContainer.dart
+++ b/Routine-Machine/lib/GreyContainer.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+class GreyContainer extends StatelessWidget {
+  final double width;
+  final double height;
+  final EdgeInsetsGeometry margin;
+  final EdgeInsetsGeometry padding;
+  final Widget child;
+
+  GreyContainer({
+    this.width = double.infinity,
+    this.height,
+    this.margin,
+    this.padding,
+    this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: this.width,
+      height: this.height,
+      margin: this.margin,
+      padding: this.padding,
+      child: this.child,
+      decoration: BoxDecoration(
+        color: Color(0xE5E5E5E5),
+        borderRadius: BorderRadius.all(
+          Radius.circular(16),
+        ),
+      ),
+    );
+  }
+}

--- a/Routine-Machine/lib/main.dart
+++ b/Routine-Machine/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:routine_machine/RoutineWidget.dart';
 import './RingProgressBar.dart';
 import './CheckInList.dart';
 
+// sample data to demo the check in list
 final sampleCheckIns = <DateTime>[
   new DateTime.now(),
   new DateTime.utc(2021, 4, 20),
@@ -20,7 +21,10 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
         body: Column(
           children: [
-            CheckInList(checkIns: sampleCheckIns),
+            CheckInList(
+              checkIns: sampleCheckIns,
+              color: 0xFFC960FF,
+            ),
             RingProgressBar(
               currentCount: 17,
               goalCount: 20,

--- a/Routine-Machine/lib/main.dart
+++ b/Routine-Machine/lib/main.dart
@@ -1,6 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:routine_machine/RoutineWidget.dart';
 
-void main() {
-  RoutineWidget r = RoutineWidget();
+import './CheckInList.dart';
+
+final sampleCheckIns = <DateTime>[
+  new DateTime.now(),
+  new DateTime.utc(2021, 4, 20),
+  new DateTime.utc(2020, 4, 30),
+];
+void main() => runApp(MyApp());
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Routine Machine',
+      home: Scaffold(
+        appBar: AppBar(title: Text('test')),
+        body: CheckInList(checkIns: sampleCheckIns),
+      ),
+    );
+  }
 }

--- a/Routine-Machine/pubspec.lock
+++ b/Routine-Machine/pubspec.lock
@@ -67,6 +67,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.16.1"
   matcher:
     dependency: transitive
     description:

--- a/Routine-Machine/pubspec.yaml
+++ b/Routine-Machine/pubspec.yaml
@@ -23,6 +23,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  intl: 0.16.1
 
 
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
Fixes #11 
Created the check-in list box. Didn't make custom bullets and used the default bullet instead, but I can make a custom bullet if we want one. Created a sample list of `DateTime` objects so you can see the list. If you pass in an empty list and hot restart the app (different than hot reload), then you'll see the empty default message. 

Also created a `GreyContainer` widget that is a grey box with rounded corners. We use it a lot in our design so I figured it'd be good to have. 

These are the properties (non are required) of `GreyContainer`:
* width (default: full width of parent)
* height
* margin
* padding

All of these are forwarded directly to a `Container` widget. 