### PR TITLE
Create profile bar view and add palette

### DIFF
--- a/Routine-Machine/lib/ProfileBarView.dart
+++ b/Routine-Machine/lib/ProfileBarView.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import './constants/Palette.dart' as Palette;
+
+class ProfileBarView extends StatelessWidget {
+  // note: assuming that firstName and lastName are not empty strings
+  final String firstName;
+  final String lastName;
+
+  ProfileBarView({this.firstName, this.lastName});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.fromLTRB(0, 16, 0, 16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          RichText(
+            text: TextSpan(
+              text: 'Hi,\n',
+              style: TextStyle(
+                color: Colors.grey,
+                fontSize: 24.0,
+              ),
+              children: [
+                TextSpan(
+                  text: '${this.firstName} ${this.lastName[0]}',
+                  style: TextStyle(
+                    color: Colors.black,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          GestureDetector(
+            onTap: () => {
+              // TODO: navigate to profile page
+              print('Clicked profile icon!')
+            },
+            child: CircleAvatar(
+              backgroundColor: Palette.primary,
+              radius: 26,
+              child: Text(
+                this.firstName[0].toUpperCase(),
+                style: TextStyle(
+                  fontSize: 32.0,
+                  color: Colors.white,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/Routine-Machine/lib/constants/Palette.dart
+++ b/Routine-Machine/lib/constants/Palette.dart
@@ -1,3 +1,3 @@
 import 'package:flutter/material.dart';
 
-const primary = Color(0xFFC960FF);
+const primary = Color(0xFFB057F5);

--- a/Routine-Machine/lib/constants/Palette.dart
+++ b/Routine-Machine/lib/constants/Palette.dart
@@ -1,0 +1,3 @@
+import 'package:flutter/material.dart';
+
+const primary = Color(0xFFC960FF);

--- a/Routine-Machine/lib/main.dart
+++ b/Routine-Machine/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:routine_machine/RoutineWidget.dart';
 
 import './RingProgressBar.dart';
 import './CheckInList.dart';
+import './ProfileBarView.dart';
 
 // sample data to demo the check in list
 final sampleCheckIns = <DateTime>[
@@ -19,19 +20,23 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Routine Machine',
       home: Scaffold(
-        body: Column(
-          children: [
-            CheckInList(
-              checkIns: sampleCheckIns,
-              color: 0xFFC960FF,
-            ),
-            RingProgressBar(
-              currentCount: 17,
-              goalCount: 20,
-              habitType: 'monthly',
-              color: 0xFFC960FF,
-            ),
-          ],
+        body: Container(
+          padding: EdgeInsets.all(16),
+          child: Column(
+            children: [
+              ProfileBarView(firstName: 'Jody', lastName: 'Lin'),
+              CheckInList(
+                checkIns: sampleCheckIns,
+                color: 0xFFC960FF,
+              ),
+              RingProgressBar(
+                currentCount: 17,
+                goalCount: 20,
+                habitType: 'monthly',
+                color: 0xFFC960FF,
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Fixes #8
Created the Profile Bar View at the top of the main dashboard. Currently, the profile icon becomes the initial of the first name passed into the Profile Bar View. The name displayed on the bar itself will be the first name and the last initial.

I also created `Palette.dart` as a way to store our main color palette. I'm not sure if there's a better way to do this, but I didn't really want to create a custom class and instantiate it just to get the color palette. If we like how this `Palette.dart` is defined and used, I will change how we pass colors to our other components. (Currently we pass the integer hex value, but this passes an entire `Color` object)