### PR TITLE
Root navigation set up

### DIFF
--- a/Routine-Machine/lib/Views/pages/HomePage.dart
+++ b/Routine-Machine/lib/Views/pages/HomePage.dart
@@ -1,19 +1,115 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_sfsymbols/flutter_sfsymbols.dart';
 import '../../constants/Palette.dart' as Palette;
 import '../components/BottomNavBar.dart';
+import 'LoginPage.dart';
+import 'package:flutter/cupertino.dart';
+import '../subviews/Dashboard.dart';
 
-class HomePage extends StatelessWidget {
+class HomePage extends StatefulWidget {
+  @override
+  _HomePageState createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  bool triedLogIn = false;
+  PageController _controller = PageController(
+    initialPage: 0,
+  );
+  int _page = 0;
+
+  final List<Widget> _children = [
+    Container(
+      color: Colors.white,
+      child: Center(
+        child: Text(
+          "Home View",
+          style: TextStyle(fontSize: 36),
+        ),
+      ),
+    ),
+    Container(
+      color: Colors.white,
+      child: Center(
+        child: Text("Another View"),
+      ),
+    ),
+    Container(
+      color: Colors.white,
+      child: Center(
+        child: Text("3rd View"),
+      ),
+    ),
+  ];
+
+  List<BottomNavigationBarItem> buildBottomNavBarItems() {
+    return [
+      BottomNavigationBarItem(
+        icon: new Icon(
+          SFSymbols.square_grid_2x2,
+          color: (_page == 0) ? Colors.black : Colors.grey,
+        ),
+        backgroundColor: Colors.white,
+      ),
+      BottomNavigationBarItem(
+        icon: new Icon(
+          SFSymbols.person_2,
+          color: (_page == 1) ? Colors.black : Colors.grey,
+        ),
+        backgroundColor: Colors.white,
+      ),
+      BottomNavigationBarItem(
+        icon: new Icon(
+          SFSymbols.gear_alt,
+          color: (_page == 2) ? Colors.black : Colors.grey,
+        ),
+        backgroundColor: Colors.white,
+      ),
+    ];
+  }
+
+  Widget loginPageBuilder() {
+    return LoginPage();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Widget buildPageView() {
+    return PageView(
+      controller: _controller,
+      onPageChanged: (index) {
+        onPageChanged(index);
+      },
+      children: this._children,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Text('Home Page'),
-      bottomNavigationBar: BottomNavBar(),
-      floatingActionButton: FloatingActionButton(
-        backgroundColor: Palette.primary,
-        child: Icon(Icons.add_rounded),
-        onPressed: () => {},
+      body: buildPageView(),
+      bottomNavigationBar: CupertinoTabBar(
+        currentIndex: _page,
+        items: buildBottomNavBarItems(),
+        onTap: (index) {
+          print(index);
+          buttonTapped(index);
+        },
       ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
     );
+  }
+
+  void onPageChanged(int page) {
+    setState(() {
+      this._page = page;
+    });
+  }
+
+  void buttonTapped(int page) {
+    this._controller.jumpToPage(page);
   }
 }

--- a/Routine-Machine/lib/Views/pages/LoginPage.dart
+++ b/Routine-Machine/lib/Views/pages/LoginPage.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-class HabitDetailPage extends StatelessWidget {
+class LoginPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/Routine-Machine/lib/Views/subviews/Dashboard.dart
+++ b/Routine-Machine/lib/Views/subviews/Dashboard.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import '../../Models/WidgetData.dart';
 
-class HomeView extends StatelessWidget {
+class Dashboard extends StatelessWidget {
   final WidgetData data;
-  HomeView(this.data);
+  Dashboard(this.data);
   @override
   Widget build(BuildContext context) {
     return MaterialApp(

--- a/Routine-Machine/lib/main.dart
+++ b/Routine-Machine/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:routine_machine/Views/pages/HomePage.dart';
 
 import 'Models/SampleFollowTileData.dart';
 import 'constants/Palette.dart' as Palette;
@@ -40,7 +41,18 @@ final List<SampleFollowTileData> sampleFollowingList = [
     color: Colors.green,
   ),
 ];
-void main() => runApp(MyApp());
+void main() => runApp(RoutineMachine());
+
+class RoutineMachine extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(fontFamily: "SF Pro Rounded"),
+      title: "Routine Machine",
+      home: HomePage(),
+    );
+  }
+}
 
 class MyApp extends StatelessWidget {
   @override


### PR DESCRIPTION
I've set up a three-page navigation to HomePage.dart, we can now implement the view of each page and replace the _children in HomePage Widget.

