### PR TITLE
Follower Request Page and Search Page

### DIFF
--- a/Routine-Machine/lib/Models/SampleFollowerRequestData.dart
+++ b/Routine-Machine/lib/Models/SampleFollowerRequestData.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class SampleFollowerRequestData {
+  final String firstName;
+  final String lastName;
+  final String userName;
+  final Color color;
+
+  SampleFollowerRequestData(
+      {this.firstName, this.lastName, this.userName, this.color});
+}

--- a/Routine-Machine/lib/Views/components/FollowRequestTile.dart
+++ b/Routine-Machine/lib/Views/components/FollowRequestTile.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import './FollowTileInfo.dart';
+import '../../constants/Palette.dart' as Palette;
+
+class FollowRequestTile extends StatelessWidget {
+  final String firstName;
+  final String lastName;
+  final String userName;
+  final String caption;
+  final Color color;
+
+  FollowRequestTile(
+      {this.firstName, this.lastName, this.userName, this.caption, this.color});
+
+  void _followUser() {
+    print('follow user @$userName!');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Row(
+        children: [
+          FollowTileInfo(
+            firstName: this.firstName,
+            lastName: this.lastName,
+            caption: this.caption,
+            color: this.color,
+          ),
+          TextButton(
+            onPressed: _followUser,
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              child: Text('Follow'),
+            ),
+            style: ButtonStyle(
+              foregroundColor: MaterialStateProperty.all(Colors.white),
+              backgroundColor: MaterialStateProperty.all(Palette.primary),
+              shape: MaterialStateProperty.all<RoundedRectangleBorder>(
+                RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(18.0),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/Routine-Machine/lib/Views/components/FollowerRequestTile.dart
+++ b/Routine-Machine/lib/Views/components/FollowerRequestTile.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import './FollowTileInfo.dart';
+import '../../constants/Palette.dart' as Palette;
+
+class FollowerRequestTile extends StatelessWidget {
+  final String firstName;
+  final String lastName;
+  final String userName;
+  final String caption;
+  final Color color;
+
+  FollowerRequestTile(
+      {this.firstName, this.lastName, this.userName, this.caption, this.color});
+
+  _acceptRequest() {
+    // TODO: properly implement this
+    print('Accepted request!');
+  }
+
+  _rejectRequest() {
+    // TODO: properly implement this
+    print('Rejected request!');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Row(
+        children: [
+          FollowTileInfo(
+            firstName: this.firstName,
+            lastName: this.lastName,
+            caption: this.caption,
+            color: this.color,
+          ),
+          Container(
+            child: Row(
+              children: [
+                IconButton(
+                  icon: Icon(Icons.check_circle_outline_rounded),
+                  color: Palette.darkGreen,
+                  iconSize: 32,
+                  onPressed: _acceptRequest,
+                ),
+                IconButton(
+                  icon: Icon(Icons.highlight_off_rounded),
+                  color: Palette.red,
+                  iconSize: 32,
+                  onPressed: _rejectRequest,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/Routine-Machine/lib/Views/pages/FollowPage.dart
+++ b/Routine-Machine/lib/Views/pages/FollowPage.dart
@@ -5,6 +5,8 @@ import '../../constants/Palette.dart' as Palette;
 import '../../constants/Constants.dart' as Constants;
 import '../../Models/SampleFollowTileData.dart';
 import '../subviews/FollowingTileList.dart';
+import '../subviews/FollowerRequestTileList.dart';
+import '../../Models/SampleFollowerRequestData.dart';
 
 final List<SampleFollowTileData> sampleFollowingList = [
   SampleFollowTileData(
@@ -69,6 +71,27 @@ final List<SampleFollowTileData> sampleFollowingList = [
     routineName: 'Hike',
     lastCheckIn: new DateTime.now().subtract(new Duration(days: 1)),
     color: Palette.blue,
+  ),
+];
+
+final List<SampleFollowerRequestData> sampleFollowerRequestList = [
+  SampleFollowerRequestData(
+    firstName: 'Carina',
+    lastName: 'Xiong',
+    userName: 'carina_x',
+    color: Palette.blue,
+  ),
+  SampleFollowerRequestData(
+    firstName: 'Jack',
+    lastName: 'Zhao',
+    userName: 'jjack_zz',
+    color: Palette.pink,
+  ),
+  SampleFollowerRequestData(
+    firstName: 'Jody',
+    lastName: 'Lin',
+    userName: 'jowody',
+    color: Palette.yellow,
   ),
 ];
 
@@ -162,9 +185,8 @@ class _FollowPageState extends State<FollowPage> {
                 ? FollowingTileList(
                     followingList: sampleFollowingList,
                   )
-                : Center(
-                    // TODO: replace with followers list
-                    child: Text('followers page'),
+                : FollowerRequestTileList(
+                    followerRequestList: sampleFollowerRequestList,
                   ),
           ),
         ],

--- a/Routine-Machine/lib/Views/pages/FollowPage.dart
+++ b/Routine-Machine/lib/Views/pages/FollowPage.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'dart:io';
 
+import 'SearchResultPage.dart';
 import '../../constants/Palette.dart' as Palette;
 import '../../constants/Constants.dart' as Constants;
 import '../../Models/SampleFollowTileData.dart';
@@ -129,6 +130,15 @@ class _FollowPageState extends State<FollowPage> {
     }
   }
 
+  void _searchForUser(BuildContext context, String userName) async {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => SearchResultPage(searchText: userName),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -172,9 +182,10 @@ class _FollowPageState extends State<FollowPage> {
                 labelText: 'Search for friends...',
                 suffixIcon: IconButton(
                   icon: Icon(Icons.search_rounded),
-                  onPressed: () {
+                  onPressed: () async {
                     // TODO: update so search for people
                     print('search for ${searchController.text}!');
+                    _searchForUser(context, searchController.text);
                   },
                 ),
               ),

--- a/Routine-Machine/lib/Views/pages/SearchResultPage.dart
+++ b/Routine-Machine/lib/Views/pages/SearchResultPage.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import '../../constants/Constants.dart' as Constants;
+import '../../constants/Palette.dart' as Palette;
+import '../subviews/FollowRequestTileList.dart';
+import '../../Models/SampleFollowerRequestData.dart';
+
+final List<SampleFollowerRequestData> sampleSearchResults = [
+  SampleFollowerRequestData(
+    firstName: 'Richard',
+    lastName: 'Tang',
+    userName: 'rich_tang',
+    color: Palette.blue,
+  ),
+  SampleFollowerRequestData(
+    firstName: 'Joohyuk',
+    lastName: 'Nam',
+    userName: 'nam_dosan',
+    color: Palette.yellow,
+  ),
+  SampleFollowerRequestData(
+    firstName: 'Richard',
+    lastName: 'Tang',
+    userName: 'rich_tang',
+    color: Palette.blue,
+  ),
+];
+
+class SearchResultPage extends StatefulWidget {
+  final String searchText;
+  SearchResultPage({this.searchText});
+  @override
+  _SearchResultPageState createState() => _SearchResultPageState(searchText);
+}
+
+class _SearchResultPageState extends State<SearchResultPage> {
+  TextEditingController searchController;
+  List<SampleFollowerRequestData> _searchResults;
+
+  _SearchResultPageState(String searchText) {
+    searchController = TextEditingController(text: searchText);
+    // Note: do NOT need to call setState() in constructor
+    _searchResults = _searchForUser(searchText);
+  }
+
+  List<SampleFollowerRequestData> _searchForUser(String userName) {
+    // TODO: search for results and return list
+    // TODO: will have to convert this to use futures
+    print('search for user $userName...');
+    return sampleSearchResults;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          onPressed: () => Navigator.pop(context),
+          icon: Icon(Icons.arrow_back_ios_rounded),
+          color: Colors.grey,
+        ),
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        elevation: 0,
+      ),
+      body: Container(
+        padding: EdgeInsets.symmetric(horizontal: 16),
+        child: Column(
+          children: [
+            Text(
+              'Search Results',
+              style: Constants.kLargeTitleStyle,
+            ),
+            Padding(
+              padding: EdgeInsets.fromLTRB(0, 16, 0, 16),
+              child: TextField(
+                controller: searchController,
+                decoration: InputDecoration(
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                  labelText: 'Search for friends...',
+                  suffixIcon: IconButton(
+                    icon: Icon(Icons.search_rounded),
+                    onPressed: () async {
+                      // TODO: update so search for people
+                      setState(() {
+                        _searchResults = _searchForUser(searchController.text);
+                      });
+                    },
+                  ),
+                ),
+              ),
+            ),
+            Expanded(
+              child: _searchResults.isEmpty // default message if no results
+                  ? Center(
+                      child: Text(
+                        'Sorry, the user "${searchController.text}" was not found',
+                        style: TextStyle(color: Colors.black),
+                      ),
+                    )
+                  : FollowRequestTileList(
+                      followRequestList: _searchResults,
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/Routine-Machine/lib/Views/subviews/FollowRequestTileList.dart
+++ b/Routine-Machine/lib/Views/subviews/FollowRequestTileList.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import '../components/FollowRequestTile.dart';
+
+class FollowRequestTileList extends StatelessWidget {
+  final List followRequestList;
+
+  FollowRequestTileList({this.followRequestList});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      itemCount: followRequestList.length,
+      shrinkWrap: true,
+      separatorBuilder: (BuildContext context, int index) => Divider(),
+      itemBuilder: (context, index) {
+        var user = followRequestList[index];
+        return FollowRequestTile(
+          firstName: user.firstName,
+          lastName: user.lastName,
+          userName: user.userName,
+          caption: '@${user.userName}',
+          color: user.color,
+        );
+      },
+    );
+  }
+}

--- a/Routine-Machine/lib/Views/subviews/FollowerRequestTileList.dart
+++ b/Routine-Machine/lib/Views/subviews/FollowerRequestTileList.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import '../components/FollowerRequestTile.dart';
+
+class FollowerRequestTileList extends StatelessWidget {
+  final List followerRequestList;
+
+  FollowerRequestTileList({this.followerRequestList});
+
+  @override
+  Widget build(BuildContext context) {
+    return this.followerRequestList.isEmpty
+        ? Text(
+            'You currently have no pending requests :)') // default message if not following anyone
+        : ListView.separated(
+            itemCount: followerRequestList.length,
+            shrinkWrap: true,
+            separatorBuilder: (BuildContext context, int index) => Divider(),
+            itemBuilder: (context, index) {
+              var user = followerRequestList[index];
+              String requestCaption = 'requests to follow you';
+              return FollowerRequestTile(
+                firstName: user.firstName,
+                lastName: user.lastName,
+                userName: user.userName,
+                caption: requestCaption,
+                color: user.color,
+              );
+            },
+          );
+  }
+}

--- a/Routine-Machine/lib/constants/Palette.dart
+++ b/Routine-Machine/lib/constants/Palette.dart
@@ -27,3 +27,7 @@ const letterLightGrey = Color(0xFF959595);
 
 //background
 const containerGrey = Color(0xFBFBFB);
+
+// colors for follow requests
+const darkGreen = Color(0xFF00B432);
+const red = Color(0xFFFF0000);


### PR DESCRIPTION
Fixes #47 and Fixes #35
Created the Follower Page and the Search Page

## Follower Page
This holds a list of pending requests. This is a list of `FollowerRequestTile` widgets. You can either accept or reject a request by pressing the check or the cross icon. 

### What's Left
* Need to implement the accept/reject functions

## Search Page
This will show the results of searching for a _username_. To search, from either the `FollowPage` or the `SearchResultsPage`, you can type in the search bar and hit the _search_ icon. (**Note:** I did not implement the functionality that pressing _Enter_ on the keyboard would also trigger the search).

You can follow then these users by clicking on the _Follow_ button. 

**How users are fetched**: The idea is that after you navigate to the search page _then_ the `SearchResultsPage` will fetch the search results. This is so there will be no delay when switching screens. 

If the search results are empty, there will be a default message that appears. 

**Design Note**: I did not completely match the design of the header text "Search Result". The figma's version is left-aligned with a notification bell on the right. I just centered my header and did not include the notification bell. Wasn't quite sure what the bell was to be used for. 

### What's Left
* Need to implement search function to search for user


**Note: _All_ of the pages/widgets will need to be refactored to take in futures. Not sure how that works completely, so pushing up the hardcoded versions right now.**