### PR TITLE
Fix plugin version dependency conflicts aaaaagghhh

### DIFF
--- a/Routine-Machine/android/app/build.gradle
+++ b/Routine-Machine/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.routine_machine"
-        minSdkVersion 16
+        minSdkVersion 18
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/Routine-Machine/lib/api/APIWrapper.dart
+++ b/Routine-Machine/lib/api/APIWrapper.dart
@@ -4,7 +4,7 @@ import 'dart:convert' as Convert;
 import '../Models/UserProfile.dart';
 
 class APIWrapper {
-  Auth.FirebaseUser user;
+  Auth.User user;
   APIWrapper(this.user);
 
   Future<UserProfile> getUserProfile({String username}) async {

--- a/Routine-Machine/pubspec.lock
+++ b/Routine-Machine/pubspec.lock
@@ -84,7 +84,21 @@ packages:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.2+1"
+    version: "1.1.2"
+  firebase_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_auth_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.0"
+  firebase_auth_web:
+    dependency: transitive
+    description:
+      name: firebase_auth_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   firebase_core:
     dependency: "direct main"
     description:
@@ -155,7 +169,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.17.0"
   js:
     dependency: transitive
     description:

--- a/Routine-Machine/pubspec.yaml
+++ b/Routine-Machine/pubspec.yaml
@@ -23,7 +23,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: 0.16.1
+  intl: ^0.17.0
   percent_indicator: "^2.1.7+2"
   flutter_sfsymbols: ^1.0.0
 
@@ -32,7 +32,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   firebase_core: ^1.1.0
-  firebase_auth: ^0.6.2+1
+  firebase_auth: ^1.1.2
   http: ^0.13.1
   flutter_secure_storage: ^4.2.0
   timeago: ^3.0.2


### PR DESCRIPTION
## tl;dr upgraded some plugins

### Firebase Auth `^0.6.2+1` --> `^1.1.2`
Upgraded the `firebase_auth` to a version that is compatible with our version of `firebase_core`.  Wasn't really sure which version to upgrade to so I just upgraded to the [latest one](https://pub.dev/packages/firebase_auth/versions). This also required us to upgrade the `intl` plugin from `0.16.0` --> `0.17.0`. 

**Note:** This upgrade contained some [breaking changes](https://pub.dev/packages/firebase_auth/changelog). One change was that the class name FirebaseUser was [renamed to User](https://pub.dev/packages/firebase_auth/changelog#0180). I updated this in the API Wrapper. 

### minSdkVersion 16 --> 18
As @rtspw mentioned, one of the plugins also required a `minSdkVersion` of 18. I also updated this. 