### PR TITLE
Implemented increment/decrement habit counter

### DIFF
--- a/Routine-Machine/lib/Views/components/RingProgressBar.dart
+++ b/Routine-Machine/lib/Views/components/RingProgressBar.dart
@@ -4,10 +4,16 @@ import 'package:percent_indicator/percent_indicator.dart';
 import 'package:flutter_sfsymbols/flutter_sfsymbols.dart';
 
 class RingProgressBar extends StatelessWidget {
-  RingProgressBar({this.currentCount, this.goalCount, habitType, color}) {
-    ringColor = color;
+  RingProgressBar({this.currentCount, this.goalCount, habitType, this.color}) {
     // if current count <= 0, default to 0.01 so a little bit of the ring is visible
-    percentComplete = currentCount > 0 ? currentCount / goalCount : 0.01;
+    if (currentCount > goalCount) {
+      _percentComplete = 1;
+    } else if (currentCount <= 0) {
+      _percentComplete = 0.01;
+    } else {
+      _percentComplete = currentCount / goalCount;
+    }
+    // percentComplete = currentCount > 0 ? currentCount / goalCount : 0.01;
     if (habitType == 'daily') {
       // perhaps want to enumerate these types somewhere
       counterLabel = 'today';
@@ -25,10 +31,10 @@ class RingProgressBar extends StatelessWidget {
   String counterLabel;
   final int currentCount;
   final int goalCount;
-  double percentComplete;
-  Color ringColor;
+  double _percentComplete;
   // not sure how sizing is done in mobile dev so hard coding here
-  double ringSize = 110;
+  final double ringSize = 110;
+  final Color color;
 
   @override
   Widget build(BuildContext context) {
@@ -43,18 +49,18 @@ class RingProgressBar extends StatelessWidget {
             child: CircularPercentIndicator(
               radius: ringSize,
               lineWidth: 5.0,
-              percent: percentComplete,
+              percent: _percentComplete,
               circularStrokeCap: CircularStrokeCap.round,
-              backgroundColor: ringColor.withOpacity(0.3),
-              progressColor: ringColor,
+              backgroundColor: color.withOpacity(0.3),
+              progressColor: color,
             ),
           ),
           Center(
-            child: percentComplete == 1
+            child: _percentComplete == 1
                 ? Icon(
                     SFSymbols.checkmark_alt,
                     size: 45,
-                    color: ringColor,
+                    color: color,
                   )
                 : RichText(
                     textAlign: TextAlign.center,

--- a/Routine-Machine/lib/Views/components/SmallWidgetView.dart
+++ b/Routine-Machine/lib/Views/components/SmallWidgetView.dart
@@ -3,7 +3,7 @@ import 'RingProgressBar.dart';
 import '../../constants/Constants.dart' as Constants;
 import '../pages/HabitDetailPage.dart';
 
-class SmallWidgetView extends StatelessWidget {
+class SmallWidgetView extends StatefulWidget {
   final String routineName;
   final String widgetType;
   final int count;
@@ -20,23 +20,44 @@ class SmallWidgetView extends StatelessWidget {
       this.color});
 
   @override
+  _SmallWidgetViewState createState() => _SmallWidgetViewState();
+}
+
+class _SmallWidgetViewState extends State<SmallWidgetView> {
+  int count = 0; // eventually just fetch this state
+
+  void _incrementCount() {
+    setState(() {
+      this.count++;
+    });
+  }
+
+  void _buildDetailPageAndAwaitCount(BuildContext context) async {
+    // when the detail page is popped
+    // it will return the updated value of count
+    // then we will set the state to match this value
+    final updatedCount = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => HabitDetailPage(
+          routineName: widget.routineName,
+          widgetType: widget.widgetType,
+          count: count,
+          goal: widget.goal,
+          checkIns: widget.checkIns,
+          color: widget.color,
+        ),
+      ),
+    );
+    setState(() {
+      count = updatedCount;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onLongPress: () async {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => HabitDetailPage(
-              routineName: this.routineName,
-              widgetType: this.widgetType,
-              count: this.count,
-              goal: this.goal,
-              checkIns: this.checkIns,
-              color: this.color,
-            ),
-          ),
-        );
-      },
+      onLongPress: () => _buildDetailPageAndAwaitCount(context),
       child: Container(
         padding: EdgeInsets.all(24),
         width: double.infinity,
@@ -48,19 +69,19 @@ class SmallWidgetView extends StatelessWidget {
             Padding(
               padding: EdgeInsets.only(bottom: 16),
               child: Text(
-                routineName,
+                widget.routineName,
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
                 style: Constants.kCardTitleStyle,
               ),
             ),
             GestureDetector(
-              onTap: () => print('increment count!'),
+              onTap: _incrementCount,
               child: RingProgressBar(
                 currentCount: count,
-                goalCount: goal,
-                habitType: widgetType,
-                color: color,
+                goalCount: widget.goal,
+                habitType: widget.widgetType,
+                color: widget.color,
               ),
             ),
           ],

--- a/Routine-Machine/lib/Views/components/TopBackBar.dart
+++ b/Routine-Machine/lib/Views/components/TopBackBar.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 
 class TopBackBar extends StatelessWidget implements PreferredSizeWidget {
-  TopBackBar({Key key})
+  final dynamic passBack;
+  TopBackBar({this.passBack, Key key})
       : preferredSize = Size.fromHeight(kToolbarHeight),
         super(
           key: key,
@@ -10,7 +11,7 @@ class TopBackBar extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     return AppBar(
       leading: IconButton(
-        onPressed: () => Navigator.pop(context),
+        onPressed: () => Navigator.pop(context, passBack),
         icon: Icon(Icons.arrow_back_ios_rounded),
         color: Colors.grey,
       ),

--- a/Routine-Machine/lib/Views/pages/HabitDetailPage.dart
+++ b/Routine-Machine/lib/Views/pages/HabitDetailPage.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import '../../constants/Constants.dart' as Constants;
+import '../../constants/Palette.dart' as Palette;
 import '../components/RingProgressBar.dart';
 import '../components/TopBackBar.dart';
 import '../subviews/CheckInList.dart';
 
-class HabitDetailPage extends StatelessWidget {
+class HabitDetailPage extends StatefulWidget {
   final String routineName;
   final String widgetType;
   final int count;
@@ -12,18 +13,40 @@ class HabitDetailPage extends StatelessWidget {
   final List<DateTime> checkIns;
   final Color color;
 
-  HabitDetailPage(
-      {this.routineName,
-      this.widgetType,
-      this.count,
-      this.goal,
-      this.checkIns,
-      this.color});
+  HabitDetailPage({
+    this.routineName,
+    this.widgetType,
+    this.count,
+    this.goal,
+    this.checkIns,
+    this.color,
+  });
+
+  @override
+  _HabitDetailPageState createState() => _HabitDetailPageState(this.count);
+}
+
+class _HabitDetailPageState extends State<HabitDetailPage> {
+  int _count;
+
+  _HabitDetailPageState(this._count);
+
+  void _incrementCount() {
+    setState(() {
+      _count++;
+    });
+  }
+
+  void _decrementCount() {
+    setState(() {
+      _count--;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: TopBackBar(),
+      appBar: TopBackBar(passBack: _count),
       body: Padding(
         padding: EdgeInsets.all(16),
         child: Container(
@@ -33,18 +56,35 @@ class HabitDetailPage extends StatelessWidget {
             child: Column(
               children: [
                 Text(
-                  routineName,
+                  widget.routineName,
                   style: Constants.kLargeTitleStyle,
                 ),
-                RingProgressBar(
-                  currentCount: count,
-                  goalCount: goal,
-                  habitType: widgetType,
-                  color: color,
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    IconButton(
+                      icon: Icon(Icons.remove_circle_rounded),
+                      color: Palette.grey,
+                      iconSize: 36,
+                      onPressed: _decrementCount,
+                    ),
+                    RingProgressBar(
+                      currentCount: _count,
+                      goalCount: widget.goal,
+                      habitType: widget.widgetType,
+                      color: widget.color,
+                    ),
+                    IconButton(
+                      icon: Icon(Icons.add_circle_rounded),
+                      color: Palette.grey,
+                      iconSize: 36,
+                      onPressed: _incrementCount,
+                    ),
+                  ],
                 ),
                 CheckInList(
-                  checkIns: checkIns,
-                  color: color,
+                  checkIns: widget.checkIns,
+                  color: widget.color,
                 )
               ],
             )),


### PR DESCRIPTION
You can now single tap a card to increment the counter. If you open the Habit Detail Page, you can also increment or decrement the counter by tapping the -/+ icons. 

Note on implementation: Due to the way pages are built, both the `SmallWidgetView` and `HabitDetailPage` had to maintain separate states that managed the `count`. `SmallWidgetView` will always pass its `count` state to the `HabitDetailPage`. However, the `HabitDetailPage` cannot both update the `SmallWidgetView`'s state AND rerender itself with the new value. This is because when the page is built via `MaterialPageRouter`, it will build with the `count` value given to it right then and there. This means that `HabitDetailPage` could update the `SmallWidgetView` state, but we won't see any live changes. 

To fix this, I had `HabitDetailPage` maintain its own `_count` state. This state is initialized to the `count` passed to it from `SmallWidgetView`. When this page is popped off the navigation stack, it will return the updated `_count` value. The `SmallWidgetView` will then take this returned value and update its own `count` state to match. 