### PR TITLE
Fixed path to logo bug on Login Page

### DIFF
--- a/Routine-Machine/lib/Views/pages/LoginPage.dart
+++ b/Routine-Machine/lib/Views/pages/LoginPage.dart
@@ -37,7 +37,7 @@ class LoginPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return FlutterLogin(
       title: 'Routine Machine',
-      logo: '../assets/images/rmlogo.png',
+      logo: 'assets/images/rmlogo.png',
       logoTag: Constants.logoTag,
       titleTag: Constants.titleTag,
 


### PR DESCRIPTION
The path to the logo image for the login page was incorrect and was throwing an exception every time the app started. I fixed the file path so the logo finally shows up and doesn't get thrown anymore. 