### PR TITLE
Follow page takes in futures, enumerated page type

### DIFF
--- a/Routine-Machine/lib/Views/pages/FollowPage.dart
+++ b/Routine-Machine/lib/Views/pages/FollowPage.dart
@@ -96,6 +96,11 @@ final List<SampleFollowerRequestData> sampleFollowerRequestList = [
   ),
 ];
 
+enum FollowPageType {
+  followers,
+  following,
+}
+
 class FollowPage extends StatefulWidget {
   @override
   _FollowPageState createState() => _FollowPageState();
@@ -105,7 +110,16 @@ class _FollowPageState extends State<FollowPage> {
   // Create a text controller and use it to retrieve the current value
   // of the TextField.
   final searchController = TextEditingController();
-  String _page = 'following';
+  FollowPageType _page = FollowPageType.following;
+  Future<List<dynamic>> _followingList;
+  Future<List<dynamic>> _followerRequestList;
+
+  @override
+  void initState() {
+    super.initState();
+    _followingList = _getFollowingList();
+    _followerRequestList = _getFollowerRequestList();
+  }
 
   @override
   void dispose() {
@@ -114,18 +128,27 @@ class _FollowPageState extends State<FollowPage> {
     super.dispose();
   }
 
+  Future<List<dynamic>> _getFollowingList() {
+    return Future.delayed(new Duration(seconds: 2), () => sampleFollowingList);
+  }
+
+  Future<List<dynamic>> _getFollowerRequestList() {
+    return Future.delayed(
+        new Duration(seconds: 2), () => sampleFollowerRequestList);
+  }
+
   void _switchToFollowers() {
-    if (_page != 'followers') {
+    if (_page != FollowPageType.followers) {
       setState(() {
-        _page = 'followers';
+        _page = FollowPageType.followers;
       });
     }
   }
 
   void _switchToFollowing() {
-    if (_page != 'following') {
+    if (_page != FollowPageType.following) {
       setState(() {
-        _page = 'following';
+        _page = FollowPageType.following;
       });
     }
   }
@@ -155,7 +178,7 @@ class _FollowPageState extends State<FollowPage> {
                 onTap: _switchToFollowing,
                 child: Text(
                   'Following',
-                  style: _page == 'following'
+                  style: _page == FollowPageType.following
                       ? Constants.kLargeTitleStyle
                       : Constants.kUnselectedTitleStyle,
                 ),
@@ -164,7 +187,7 @@ class _FollowPageState extends State<FollowPage> {
                 onTap: _switchToFollowers,
                 child: Text(
                   'Followers',
-                  style: _page == 'followers'
+                  style: _page == FollowPageType.followers
                       ? Constants.kLargeTitleStyle
                       : Constants.kUnselectedTitleStyle,
                 ),
@@ -192,14 +215,45 @@ class _FollowPageState extends State<FollowPage> {
             ),
           ),
           Expanded(
-            child: _page == 'following'
-                ? FollowingTileList(
-                    followingList: sampleFollowingList,
-                  )
-                : FollowerRequestTileList(
-                    followerRequestList: sampleFollowerRequestList,
-                  ),
-          ),
+              child: FutureBuilder(
+            future: Future.wait([_followingList, _followerRequestList]),
+            builder:
+                (BuildContext context, AsyncSnapshot<List<dynamic>> snapshot) {
+              Widget followContent;
+              if (snapshot.hasData) {
+                followContent = _page == FollowPageType.following
+                    ? RefreshIndicator(
+                        onRefresh: () async {
+                          setState(() {
+                            _followingList = _getFollowingList();
+                          });
+                        },
+                        child: FollowingTileList(
+                          followingList: snapshot.data[0],
+                        ),
+                      )
+                    : RefreshIndicator(
+                        onRefresh: () async {
+                          setState(() {
+                            _followerRequestList = _getFollowerRequestList();
+                          });
+                        },
+                        child: FollowerRequestTileList(
+                          followerRequestList: snapshot.data[1],
+                        ),
+                      );
+              } else if (snapshot.hasError) {
+                followContent = Center(
+                  child: Text('Error loading follow data'),
+                );
+              } else {
+                followContent = Center(
+                  child: Text('loading follow data...'),
+                );
+              }
+              return followContent;
+            },
+          )),
         ],
       ),
     );


### PR DESCRIPTION
#76 

Follow Page now takes in futures for both the `_followingList` and the `_followersRequestList`. The page will first load both futures in when the page is initially built. Then you can swipe down on each list to refresh the specific lists' contents. 

Same annoyance as before, were swiping does not reset the future so the old contents will remain showing until the new future is loaded in. 

I also added a `FollowPageType` enum so we don't have to rely on strings to check if we are on the `Following` page or the `Followers` page. 