### PR TITLE
Connect friend profile page with following page

### DIFF
--- a/Routine-Machine/lib/Models/UserProfile.dart
+++ b/Routine-Machine/lib/Models/UserProfile.dart
@@ -11,8 +11,10 @@ String userProfileToJson(UserProfile data) => json.encode(data.toJson());
 
 class UserProfile {
   UserProfile({
+    this.userID,
     this.username,
-    this.alias,
+    this.firstName,
+    this.lastName,
     this.email,
     this.follower,
     this.following,
@@ -20,8 +22,10 @@ class UserProfile {
     this.pendingFollowing,
   });
 
+  String userID;
   String username;
-  String alias;
+  String firstName;
+  String lastName;
   String email;
   List<String> follower;
   List<String> following;
@@ -29,8 +33,10 @@ class UserProfile {
   List<String> pendingFollowing;
 
   factory UserProfile.fromJson(Map<String, dynamic> json) => UserProfile(
+        userID: json["userID"],
         username: json["username"],
-        alias: json["alias"],
+        firstName: json["firstName"],
+        lastName: json["lastName"],
         email: json["email"],
         follower: List<String>.from(json["follower"].map((x) => x)),
         following: List<String>.from(json["following"].map((x) => x)),
@@ -41,8 +47,10 @@ class UserProfile {
       );
 
   Map<String, dynamic> toJson() => {
+        "userID": userID,
         "username": username,
-        "alias": alias,
+        "firstName": firstName,
+        "lastName": lastName,
         "email": email,
         "follower": List<dynamic>.from(follower.map((x) => x)),
         "following": List<dynamic>.from(following.map((x) => x)),

--- a/Routine-Machine/lib/Views/components/FollowingTile.dart
+++ b/Routine-Machine/lib/Views/components/FollowingTile.dart
@@ -1,18 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:routine_machine/Views/pages/FriendProfilePage.dart';
-import 'package:routine_machine/Models/FriendStatus.dart';
-import 'package:routine_machine/Models/UserData.dart';
 import 'package:routine_machine/Models/UserProfile.dart';
-import 'package:routine_machine/Models/WidgetData.dart';
 import './FollowTileInfo.dart';
 
 class FollowingTile extends StatelessWidget {
-  final String firstName;
-  final String lastName;
-  final String caption;
+  final UserProfile followingProfile;
   final Color color;
 
-  FollowingTile({this.firstName, this.lastName, this.caption, this.color});
+  FollowingTile({this.followingProfile, this.color});
 
   @override
   Widget build(BuildContext context) {
@@ -20,9 +15,9 @@ class FollowingTile extends StatelessWidget {
       child: Row(
         children: [
           FollowTileInfo(
-            firstName: this.firstName,
-            lastName: this.lastName,
-            caption: this.caption,
+            firstName: this.followingProfile.firstName,
+            lastName: this.followingProfile.lastName,
+            caption: '@${this.followingProfile.username}',
             color: this.color,
           ),
           IconButton(
@@ -33,15 +28,8 @@ class FollowingTile extends StatelessWidget {
                 context,
                 MaterialPageRoute(
                   builder: (context) => FriendProfilePage(
-                    friendData: UserData(
-                      profile: UserProfile(
-                          alias: "Jack Zhao", username: "jackzhao98"),
-                      data: [
-                        WidgetData.widgetSample1,
-                        WidgetData.widgetSample3
-                      ],
-                    ),
-                    friendStatus: FriendStatus.follower,
+                    friendProfile: followingProfile,
+                    userColor: this.color,
                   ),
                 ),
               );

--- a/Routine-Machine/lib/Views/components/LongWidgetView.dart
+++ b/Routine-Machine/lib/Views/components/LongWidgetView.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import '../../Views/components/RingProgressBar.dart';
+import '../../Models/WidgetData.dart';
+import '../../constants/Constants.dart' as Constants;
+import 'package:timeago/timeago.dart' as timeago;
+
+class LongWidgetView extends StatelessWidget {
+  final WidgetData data;
+  final double rowHeight = 90;
+  final double paddingRate = 0.15;
+
+  LongWidgetView(this.data);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(paddingRate * rowHeight),
+      height: rowHeight,
+      width: MediaQuery.of(context).size.width,
+      decoration: Constants.kCardDecorationStyle,
+      child: Padding(
+        padding: const EdgeInsets.only(left: 20),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            RingProgressBar(
+              currentCount: data.currentPeriodCounts,
+              goalCount: data.periodicalGoal,
+              habitType: data.widgetType,
+              color: Color(data.color),
+              showText: false,
+              ringSize: (1 - 2 * paddingRate) * rowHeight,
+            ),
+            Flexible(
+              child: Padding(
+                padding: const EdgeInsets.only(left: 20),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      "${data.title} ${data.currentPeriodCounts}/${data.periodicalGoal}",
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Constants.kTitle2Style,
+                    ),
+                    if (data.checkins.length > 0)
+                      Text(
+                          "Last checked at ${timeago.format(data.checkins.last)}")
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/Routine-Machine/lib/Views/pages/FollowPage.dart
+++ b/Routine-Machine/lib/Views/pages/FollowPage.dart
@@ -4,75 +4,57 @@ import 'dart:io';
 import 'SearchResultPage.dart';
 import '../../constants/Palette.dart' as Palette;
 import '../../constants/Constants.dart' as Constants;
-import '../../Models/SampleFollowTileData.dart';
 import '../subviews/FollowingTileList.dart';
 import '../subviews/FollowerRequestTileList.dart';
 import '../../Models/SampleFollowerRequestData.dart';
+import '../../Models/UserProfile.dart';
 
-final List<SampleFollowTileData> sampleFollowingList = [
-  SampleFollowTileData(
+final List<UserProfile> sampleFollowingList = [
+  UserProfile(
     firstName: 'Spencer',
     lastName: 'Jin',
-    routineName: 'Workout',
-    lastCheckIn: new DateTime.now(),
-    color: Palette.pink,
+    username: 'sj_sj_sj',
   ),
-  SampleFollowTileData(
-    firstName: 'Lee',
-    lastName: 'Jieun',
-    routineName: 'Practice singing',
-    lastCheckIn: new DateTime.now().subtract(new Duration(minutes: 15)),
-    color: Palette.purple,
-  ),
-  SampleFollowTileData(
+  UserProfile(
     firstName: 'Erika',
     lastName: 'Shen',
-    routineName: 'Hike',
-    lastCheckIn: new DateTime.now().subtract(new Duration(days: 1)),
-    color: Palette.blue,
+    username: 'eggy',
   ),
-  SampleFollowTileData(
+  UserProfile(
+    firstName: 'Jody',
+    lastName: 'Lin',
+    username: 'jowody',
+  ),
+  UserProfile(
     firstName: 'Spencer',
     lastName: 'Jin',
-    routineName: 'Workout',
-    lastCheckIn: new DateTime.now(),
-    color: Palette.pink,
+    username: 'sj_sj_sj',
   ),
-  SampleFollowTileData(
-    firstName: 'Lee',
-    lastName: 'Jieun',
-    routineName: 'Practice singing',
-    lastCheckIn: new DateTime.now().subtract(new Duration(minutes: 15)),
-    color: Palette.purple,
-  ),
-  SampleFollowTileData(
+  UserProfile(
     firstName: 'Erika',
     lastName: 'Shen',
-    routineName: 'Hike',
-    lastCheckIn: new DateTime.now().subtract(new Duration(days: 1)),
-    color: Palette.blue,
+    username: 'eggy',
   ),
-  SampleFollowTileData(
+  UserProfile(
+    firstName: 'Jody',
+    lastName: 'Lin',
+    username: 'jowody',
+  ),
+  UserProfile(
     firstName: 'Spencer',
     lastName: 'Jin',
-    routineName: 'Workout',
-    lastCheckIn: new DateTime.now(),
-    color: Palette.pink,
+    username: 'sj_sj_sj',
   ),
-  SampleFollowTileData(
-    firstName: 'Lee',
-    lastName: 'Jieun',
-    routineName: 'Practice singing',
-    lastCheckIn: new DateTime.now().subtract(new Duration(minutes: 15)),
-    color: Palette.purple,
-  ),
-  SampleFollowTileData(
+  UserProfile(
     firstName: 'Erika',
     lastName: 'Shen',
-    routineName: 'Hike',
-    lastCheckIn: new DateTime.now().subtract(new Duration(days: 1)),
-    color: Palette.blue,
+    username: 'eggy',
   ),
+  UserProfile(
+    firstName: 'Jody',
+    lastName: 'Lin',
+    username: 'jowody',
+  )
 ];
 
 final List<SampleFollowerRequestData> sampleFollowerRequestList = [

--- a/Routine-Machine/lib/Views/pages/FriendProfilePage.dart
+++ b/Routine-Machine/lib/Views/pages/FriendProfilePage.dart
@@ -1,20 +1,59 @@
 import 'package:flutter/material.dart';
 import 'dart:io';
-import 'package:routine_machine/Models/UserData.dart';
-import 'package:routine_machine/Views/subviews/friendWidgetList.dart';
-import '../../constants/Palette.dart' as Palette;
+import 'package:routine_machine/Views/subviews/FriendWidgetList.dart';
 import '../../constants/Constants.dart';
 import '../components/TopBackBar.dart';
 import '../../Models/FriendStatus.dart';
+import '../../Models/UserProfile.dart';
+import '../../Models/WidgetData.dart';
 
-import '../../Models/UserData.dart';
+List<WidgetData> sampleWidgetData = [
+  WidgetData(
+    title: "Sample",
+    widgetType: "weekly",
+    color: 0xffffaabb,
+    createdTime: new DateTime.now(),
+    modifiedTime: new DateTime.now(),
+    currentPeriodCounts: 15,
+    periodicalGoal: 20,
+    checkins: [new DateTime.now(), new DateTime.now()],
+  ),
+  WidgetData(
+    title: "Pooop",
+    widgetType: "daily",
+    color: 0xFF7CD0FF,
+    createdTime: new DateTime.now(),
+    modifiedTime: new DateTime.now(),
+    currentPeriodCounts: 8,
+    periodicalGoal: 20,
+    checkins: [new DateTime.now(), new DateTime.now()],
+  ),
+];
 
-class FriendProfilePage extends StatelessWidget {
-  final UserData friendData;
-  FriendStatus friendStatus;
+class FriendProfilePage extends StatefulWidget {
+  final UserProfile friendProfile;
+  FriendStatus friendStatus; // TODO: figure out what to do with this variable
+  final Color userColor;
 
+  FriendProfilePage({this.friendProfile, this.friendStatus, this.userColor});
 
-  FriendProfilePage({this.friendData, this.friendStatus});
+  @override
+  _FriendProfilePageState createState() => _FriendProfilePageState();
+}
+
+class _FriendProfilePageState extends State<FriendProfilePage> {
+  Future<List<WidgetData>> _friendWidgetDataList;
+
+  @override
+  void initState() {
+    super.initState();
+    _friendWidgetDataList = _getFriendWidgetData();
+  }
+
+  Future<List<WidgetData>> _getFriendWidgetData() {
+    // TODO: replace this with actual APIWrapper call
+    return Future.delayed(new Duration(seconds: 2), () => sampleWidgetData);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -26,10 +65,10 @@ class FriendProfilePage extends StatelessWidget {
             children: [
               // Image here
               CircleAvatar(
-                backgroundColor: Palette.primary,
+                backgroundColor: widget.userColor,
                 radius: 50,
                 child: Text(
-                  this.friendData.profile.alias[0].toUpperCase(),
+                  '${widget.friendProfile.firstName[0].toUpperCase()}',
                   style: TextStyle(
                     fontFamily: Platform.isIOS ? 'SF Pro Text' : null,
                     fontSize: 47.0,
@@ -44,23 +83,37 @@ class FriendProfilePage extends StatelessWidget {
                 child: Column(
                   children: [
                     Text(
-                      friendData.profile.alias,
+                      '${widget.friendProfile.firstName} ${widget.friendProfile.lastName}',
                       style: kTitle1Style,
                     ),
                     Text(
-                      "@${friendData.profile.username}",
+                      "@${widget.friendProfile.username}",
                       style: kCaptionLabelStyle,
                     ),
                   ],
                 ),
               ),
-
-              Padding(
-                padding: const EdgeInsets.fromLTRB(20, 0, 20, 30),
-                child: FriendWidgetList(
-                  data: friendData.data,
-                ),
-              ),
+              FutureBuilder(
+                  future: _friendWidgetDataList,
+                  builder: (BuildContext context,
+                      AsyncSnapshot<List<WidgetData>> snapshot) {
+                    Widget friendDataContent;
+                    if (snapshot.hasData) {
+                      friendDataContent = Padding(
+                        padding: const EdgeInsets.fromLTRB(20, 0, 20, 30),
+                        child: FriendWidgetList(
+                          data: snapshot.data,
+                        ),
+                      );
+                    } else if (snapshot.hasError) {
+                      friendDataContent =
+                          Center(child: Text('Error loading follower data'));
+                    } else {
+                      friendDataContent =
+                          Center(child: Text('Loading friend\'s data...'));
+                    }
+                    return friendDataContent;
+                  }),
             ],
           ),
         ),

--- a/Routine-Machine/lib/Views/subviews/FollowingTileList.dart
+++ b/Routine-Machine/lib/Views/subviews/FollowingTileList.dart
@@ -1,6 +1,15 @@
 import 'package:flutter/material.dart';
 import '../components/FollowingTile.dart';
-import 'package:timeago/timeago.dart' as timeago;
+import '../../constants/Palette.dart' as Palette;
+
+final List colors = [
+  Palette.pink,
+  Palette.yellow,
+  Palette.orange,
+  Palette.green,
+  Palette.blue,
+  Palette.purple,
+];
 
 class FollowingTileList extends StatelessWidget {
   final List followingList;
@@ -17,14 +26,9 @@ class FollowingTileList extends StatelessWidget {
             shrinkWrap: true,
             separatorBuilder: (BuildContext context, int index) => Divider(),
             itemBuilder: (context, index) {
-              var user = followingList[index];
-              String lastRoutineCheckIn =
-                  '${user.routineName} ${timeago.format(user.lastCheckIn)}';
               return FollowingTile(
-                firstName: user.firstName,
-                lastName: user.lastName,
-                caption: lastRoutineCheckIn,
-                color: user.color,
+                followingProfile: followingList[index],
+                color: colors[index % colors.length],
               );
             },
           );

--- a/Routine-Machine/lib/Views/subviews/friendWidgetList.dart
+++ b/Routine-Machine/lib/Views/subviews/friendWidgetList.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:routine_machine/Views/components/RingProgressBar.dart';
 import '../../Models/WidgetData.dart';
-import '../../constants/Constants.dart' as Constants;
+import '../components/LongWidgetView.dart';
 
 class FriendWidgetList extends StatelessWidget {
   final List<WidgetData> data;
@@ -13,67 +12,7 @@ class FriendWidgetList extends StatelessWidget {
     return Container(
       child: Wrap(
         runSpacing: 20,
-        children: [
-          for (var d in this.data) LongWidgetView(d),
-          for (var d in this.data) LongWidgetView(d),
-          for (var d in this.data) LongWidgetView(d),
-          for (var d in this.data) LongWidgetView(d),
-        ],
-      ),
-    );
-  }
-}
-
-class LongWidgetView extends StatelessWidget {
-  final WidgetData data;
-  final double rowHeight = 90;
-  final double paddingRate = 0.15;
-
-  LongWidgetView(this.data);
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: EdgeInsets.all(paddingRate * rowHeight),
-      height: rowHeight,
-      width: MediaQuery.of(context).size.width,
-      decoration: Constants.kCardDecorationStyle,
-      child: Padding(
-        padding: const EdgeInsets.only(left: 20),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            RingProgressBar(
-              currentCount: data.currentPeriodCounts,
-              goalCount: data.periodicalGoal,
-              habitType: data.widgetType,
-              color: Color(data.color),
-              showText: false,
-              ringSize: (1 - 2 * paddingRate) * rowHeight,
-            ),
-            Flexible(
-              child: Padding(
-                padding: const EdgeInsets.only(left: 20),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      "${data.title} ${data.currentPeriodCounts}/${data.periodicalGoal}",
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: Constants.kTitle2Style,
-                    ),
-                    if (data.checkins.length > 0)
-                      Text("Last checked at ${data.checkins.last}")
-                  ],
-                ),
-              ),
-            ),
-          ],
-        ),
+        children: data.map((widgetData) => LongWidgetView(widgetData)).toList(),
       ),
     );
   }


### PR DESCRIPTION
Fixes #84 
Connected the Following Page to the Friend's Profile page. Some **notable** changes. 

## Additions
### `LongWidgetView`
* This used to be part of the `FriendWidgetList` file, but I moved it into its own component in the component folder to keep consistent with our current organization. 
* A minor change to this file was that the `DateTime` object was converted to a readable phrase like "2 mins ago" using the `intl` plugin. 

## Changes
### `FriendProfilePage`
* All widget data is now loaded **directly in this page**. (It used to be passed in as a parameter before). 
  > this is because before we fetched ALL habit data for each user we are following on the _Following_ page. However, this 
  > is very messy because when we want to just get the updated list for just one user, we'll have to constantly re-query for 
  > _everyone's_ data. Although the downside is that the tile caption no longer says the last completed habit, this will
  > save us from having to re-query then decrypt habit data from everyone in the following list all the time. 
* The only data passed into this page is the `UserProfile` data (which we will use to fetch habit data) and a color for the profile. The color of the profile is determined by the index a user fell on the `FollowingTileList`. 

### `FollowPage`
* The following list is now just a list of `UserProfile` data. This data was then passed down through `FollowingTileList` and `FollowingTile`. 

### `FriendWidgetList`
* This now will create a list of `LongWidgetView` instead of hardcoding it as it did before. 

### `UserProfile`
* changed `alias` to `firstName` and `lastName` is this is what our backend returns. 
* added a `userID` property since this is what our backend returns. The `userID` will later be needed to fetch the habit data for users we are following. 