### PR TITLE
Add qr scanner to app

### DIFF
--- a/Routine-Machine/android/app/build.gradle
+++ b/Routine-Machine/android/app/build.gradle
@@ -36,7 +36,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.routine_machine"
-        minSdkVersion 18
+        minSdkVersion 20
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/Routine-Machine/ios/Runner/Info.plist
+++ b/Routine-Machine/ios/Runner/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>io.flutter.embedded_views_preview</key>
+	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>This app needs camera access to scan QR codes</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/Routine-Machine/lib/Views/pages/LoginPage.dart
+++ b/Routine-Machine/lib/Views/pages/LoginPage.dart
@@ -8,16 +8,31 @@ import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import '../../constants/Constants.dart' as Constants;
 import '../components/custom_route.dart';
 import 'package:routine_machine/Views/pages/HomePage.dart';
+import 'ScanQRPage.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'dart:io' show Platform;
 
 FirebaseAuth _auth = FirebaseAuth.instance;
 final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 enum authProblems { UserNotFound, PasswordNotValid, NetworkError }
+enum SignInType { signUp, logIn }
 
-class LoginPage extends StatelessWidget {
+class LoginPage extends StatefulWidget {
   static const routeName = '/auth';
+
+  @override
+  _LoginPageState createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
   Duration get loginTime => Duration(milliseconds: timeDilation.ceil() * 2250);
+  SignInType _signInType = SignInType.logIn;
+
+  bool _keyExistsOnDevice() {
+    // TODO: implement this
+    return false; // set to true to bypass qr scanner page
+  }
+
   Future<String> _loginUser(LoginData loginData) async {
     try {
       final User user = (await _auth.signInWithEmailAndPassword(
@@ -132,20 +147,38 @@ class LoginPage extends StatelessWidget {
         print('Login');
         print('Email: ${loginData.name}');
         print('Password: ${loginData.password}');
+        setState(() {
+          _signInType = SignInType.logIn;
+        });
         return _loginUser(loginData);
       },
       onSignup: (loginData) async {
         print('Sign Up');
         print('Email: ${loginData.name}');
         print('Password: ${loginData.password}');
+        setState(() {
+          _signInType = SignInType.signUp;
+        });
         return _registerUser(loginData);
       },
       onSubmitAnimationCompleted: () {
         // no error found, login success
         // redirect to home page
-        Navigator.of(context).pushReplacement(FadePageRoute(
-          builder: (context) => HomePage(),
-        ));
+        if (_signInType == SignInType.signUp) {
+          Navigator.of(context).pushReplacement(FadePageRoute(
+            builder: (context) => HomePage(),
+          ));
+        } else if (_signInType == SignInType.logIn) {
+          if (_keyExistsOnDevice()) {
+            // TODO: implement this function above
+            Navigator.of(context).pushReplacement(
+                FadePageRoute(builder: (context) => HomePage()));
+          } else {
+            // go to scan page
+            Navigator.of(context).pushReplacement(
+                FadePageRoute(builder: (context) => ScanQRPage()));
+          }
+        }
       },
       onRecoverPassword: null,
       showDebugButtons: false,

--- a/Routine-Machine/lib/Views/pages/ScanQRPage.dart
+++ b/Routine-Machine/lib/Views/pages/ScanQRPage.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'dart:io';
+import 'package:qr_code_scanner/qr_code_scanner.dart';
+import 'package:routine_machine/Views/components/custom_route.dart';
+import './HomePage.dart';
+import '../../constants/Constants.dart' as Constants;
+import '../../constants/Palette.dart' as Palette;
+
+enum VerificationStatus {
+  pending,
+  success,
+  failed,
+}
+
+class ScanQRPage extends StatefulWidget {
+  @override
+  _ScanQRPageState createState() => _ScanQRPageState();
+}
+
+class _ScanQRPageState extends State<ScanQRPage> {
+  VerificationStatus _verificationStatus = VerificationStatus.pending;
+  Barcode result;
+  QRViewController controller;
+  final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+
+  @override
+  void reassemble() {
+    super.reassemble();
+    if (Platform.isAndroid) {
+      controller.pauseCamera();
+    }
+    controller.resumeCamera();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var scanArea = (MediaQuery.of(context).size.width < 400 ||
+            MediaQuery.of(context).size.height < 400)
+        ? 150.0
+        : 300.0;
+    return Scaffold(
+      body: Column(
+        children: <Widget>[
+          Expanded(
+            flex: 2,
+            child: QRView(
+              key: qrKey,
+              onQRViewCreated: _onQRViewCreated,
+              overlay: QrScannerOverlayShape(
+                borderColor: Palette.primary,
+                borderRadius: 10,
+                borderLength: 30,
+                borderWidth: 10,
+                cutOutSize: scanArea,
+              ),
+            ),
+          ),
+          Expanded(
+            flex: 1,
+            child: _verificationStatus == VerificationStatus.success
+                ? Center(
+                    child: Text('Success!', style: Constants.kTitle1Style),
+                  )
+                : Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      _verificationStatus == VerificationStatus.failed
+                          ? Text(
+                              'Invalid Code',
+                              style: Constants.kUnselectedTitleStyle,
+                            )
+                          : RichText(
+                              textAlign: TextAlign.center,
+                              text: TextSpan(
+                                style: Constants.kUnselectedTitleStyle,
+                                children: [
+                                  TextSpan(
+                                      text: 'New device',
+                                      style: TextStyle(color: Palette.primary)),
+                                  TextSpan(
+                                    text: ' login detected\n',
+                                  ),
+                                  TextSpan(text: 'Please verify your identity')
+                                ],
+                              ),
+                            ),
+                      Padding(
+                        padding: EdgeInsets.symmetric(vertical: 16),
+                        child: Text(
+                          'Scan QR Code',
+                          style: Constants.kTitle1Style,
+                        ),
+                      ),
+                      Text(
+                        'On a logged-in device,\n find under Account > View Credentials',
+                        style: Constants.kBodyLabelStyle,
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool _validateQRCode(Barcode qrCode) {
+    // TODO: validate that QRCode works
+    String key = qrCode.code;
+    return true;
+  }
+
+  void _onQRViewCreated(QRViewController controller) {
+    this.controller = controller;
+    controller.scannedDataStream.listen((scanData) {
+      setState(() {
+        if (scanData.format == BarcodeFormat.qrcode) {
+          if (_validateQRCode(scanData)) {
+            _verificationStatus = VerificationStatus.success;
+            Navigator.pushReplacement(
+              context,
+              FadePageRoute(builder: (context) => HomePage()),
+            );
+          } else {
+            _verificationStatus = VerificationStatus.failed;
+          }
+        }
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+}

--- a/Routine-Machine/lib/main.dart
+++ b/Routine-Machine/lib/main.dart
@@ -6,6 +6,8 @@ import 'Views/pages/LoginPage.dart';
 import 'Views/components/transition_route_observer.dart';
 import 'package:firebase_core/firebase_core.dart';
 
+import 'Views/pages/ScanQRPage.dart';
+
 // sample data to demo the check in list
 final sampleCheckIns = <DateTime>[
   new DateTime.now(),
@@ -24,6 +26,7 @@ class RoutineMachine extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
+      // home: ScanQRPage(),
       home: LoginPage(),
       //sample login page
       title: 'Routine Machine',

--- a/Routine-Machine/pubspec.lock
+++ b/Routine-Machine/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -492,6 +492,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  qr_code_scanner:
+    dependency: "direct main"
+    description:
+      name: qr_code_scanner
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0"
   qr_flutter:
     dependency: "direct main"
     description:
@@ -552,7 +559,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
@@ -601,7 +608,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.2.19"
   timeago:
     dependency: "direct main"
     description:

--- a/Routine-Machine/pubspec.yaml
+++ b/Routine-Machine/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   json_annotation: ^4.0.1
   mock_data: ^1.2.8
   qr_flutter: ^4.0.0
+  qr_code_scanner: ^0.4.0
   sign_in_with_apple: ^3.0.0
   sliding_up_panel: ^2.0.0+1
 


### PR DESCRIPTION
Some **important** changes

* added `qr_code_scanner` plugin. @JackZhao98 can you check to see that it works for iOS? I had to add some lines into `ios/Runner/Info.plist` for iOS, but couldn't test it to see if it actually worked
* `minSDKVersion` 18 -> 20 to support the QR Code scanner library
* The log in page now navigates to the QR page before going to the main dashboard. Only when a QR code is scanned (right now _any_ QR code works), then will it navigate to the main dashboard. The sign up page goes directly to the main dashboard though. 