### PR TITLE
Fix bug of missing follower list

### DIFF
--- a/Routine-Machine/lib/Views/subviews/FollowerTileList.dart
+++ b/Routine-Machine/lib/Views/subviews/FollowerTileList.dart
@@ -16,7 +16,7 @@ class FollowerTileList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return this.followerRequestList.isEmpty
+    return this.combinedFollowerList.isEmpty
         ? Text(
             'You currently have no pending requests or followers:)') // default message if not following anyone
         : ListView.separated(


### PR DESCRIPTION
I was checking the if the wrong list was empty. Follower list should now display both the pending follow requests and the follower list.