### PR TITLE
check follow status before enabling follow request

### DIFF
--- a/Routine-Machine/lib/Views/components/FollowRequestTile.dart
+++ b/Routine-Machine/lib/Views/components/FollowRequestTile.dart
@@ -3,8 +3,10 @@ import 'package:routine_machine/api/APIWrapper.dart';
 import './FollowTileInfo.dart';
 import '../../constants/Palette.dart' as Palette;
 import '../../Models/UserProfile.dart';
+import '../../constants/Constants.dart' as Constants;
 
 enum FollowStatus {
+  none,
   pending,
   following,
 }
@@ -21,12 +23,35 @@ class FollowRequestTile extends StatefulWidget {
 }
 
 class _FollowRequestTileState extends State<FollowRequestTile> {
-  FollowStatus _followStatus =
-      FollowStatus.pending; // TODO: initialize with actual following status
+  Future<FollowStatus> _followStatus;
+
+  @override
+  void initState() {
+    super.initState();
+    _followStatus = _getFollowStatus();
+  }
+
+  Future<FollowStatus> _getFollowStatus() async {
+    List<UserProfile> followingRequests =
+        await widget.api.getPendingFollowingRequests();
+    List<UserProfile> followingList = await widget.api.getFollowing();
+
+    for (var request in followingRequests) {
+      if (request.userID == widget.userProfile.userID) {
+        return FollowStatus.pending;
+      }
+    }
+    for (var followingUser in followingList) {
+      if (followingUser.userID == widget.userProfile.userID) {
+        return FollowStatus.following;
+      }
+    }
+    return FollowStatus.none;
+  }
 
   void _followUser() {
     setState(() {
-      _followStatus = FollowStatus.following;
+      _followStatus = Future.value(FollowStatus.pending);
     });
     widget.api.sendFollowRequest(targetUserID: widget.userProfile.userID);
     print('follow user @${this.widget.userProfile.username}!');
@@ -43,24 +68,51 @@ class _FollowRequestTileState extends State<FollowRequestTile> {
             caption: '@${this.widget.userProfile.username}',
             color: this.widget.color,
           ),
-          _followStatus == FollowStatus.pending
-              ? TextButton(
-                  onPressed: _followUser,
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 16),
-                    child: Text('Follow'),
-                  ),
-                  style: ButtonStyle(
-                    foregroundColor: MaterialStateProperty.all(Colors.white),
-                    backgroundColor: MaterialStateProperty.all(Palette.primary),
-                    shape: MaterialStateProperty.all<RoundedRectangleBorder>(
-                      RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(18.0),
-                      ),
-                    ),
-                  ),
-                )
-              : Text('request sent'),
+          FutureBuilder(
+              future: _followStatus,
+              builder:
+                  (BuildContext context, AsyncSnapshot<FollowStatus> snapshot) {
+                Widget statusWidget;
+                if (snapshot.hasData) {
+                  statusWidget = snapshot.data == FollowStatus.none
+                      ? TextButton(
+                          onPressed: _followUser,
+                          child: Padding(
+                            padding: EdgeInsets.symmetric(horizontal: 16),
+                            child: Text('Follow'),
+                          ),
+                          style: ButtonStyle(
+                            foregroundColor:
+                                MaterialStateProperty.all(Colors.white),
+                            backgroundColor:
+                                MaterialStateProperty.all(Palette.primary),
+                            shape: MaterialStateProperty.all<
+                                RoundedRectangleBorder>(
+                              RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(18.0),
+                              ),
+                            ),
+                          ),
+                        )
+                      : snapshot.data == FollowStatus.pending
+                          ? Text(
+                              'requested',
+                              style: Constants.kBodyLabelStyle,
+                            )
+                          : Text(
+                              'following',
+                              style: Constants.kBodyLabelStyle,
+                            );
+                } else if (snapshot.hasError) {
+                  statusWidget = Text(
+                    'error',
+                    style: Constants.kBodyLabelStyle,
+                  );
+                } else {
+                  statusWidget = Text('');
+                }
+                return statusWidget;
+              }),
         ],
       ),
     );

--- a/Routine-Machine/lib/Views/pages/SearchResultPage.dart
+++ b/Routine-Machine/lib/Views/pages/SearchResultPage.dart
@@ -71,20 +71,17 @@ class _SearchResultPageState extends State<SearchResultPage> {
                   (BuildContext context, AsyncSnapshot<UserProfile> snapshot) {
                 Widget searchContent;
                 if (snapshot.hasData) {
-                  searchContent =
-                      // TODO: figure out what to do when user not found
-                      // Center(
-                      //     child: Text(
-                      //       'Sorry, the user "${searchController.text}" was not found',
-                      //       style: TextStyle(color: Colors.black),
-                      //     ),
-                      //   )
-                      FollowRequestTile(
+                  searchContent = FollowRequestTile(
                     userProfile: snapshot.data,
                     color: Palette.purple,
                   );
                 } else if (snapshot.hasError) {
-                  searchContent = Text('Error loading username data');
+                  searchContent = Center(
+                    child: Text(
+                      'Sorry, user with username "${searchController.text}" was not found',
+                      style: TextStyle(color: Colors.black),
+                    ),
+                  );
                 } else {
                   searchContent = Column(
                     mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
When searching for users, you can only send a request if you have not already requested them. If you have already requested them, you will either see `following` or `requested`, indicating the status of the request. 

If a user doesn't exist, we'll display an error saying that the user couldn't be found. 