### PR TITLE
Validate device private key branch

### DIFF
--- a/Routine-Machine/lib/api/APIWrapper.dart
+++ b/Routine-Machine/lib/api/APIWrapper.dart
@@ -128,6 +128,29 @@ class APIWrapper {
     }
   }
 
+  Future<bool> validateDevicePrivateKey() async {
+    final headers = {
+      HttpHeaders.authorizationHeader: await _getAuthHeader(),
+    };
+    final url = Uri.https(apiBaseURL, '/challenge');
+    final response = await client.get(url, headers: headers);
+    if (response.statusCode != 200) {
+      throw Exception('Failed to get private key challenge');
+    }
+    final json = Convert.jsonDecode(response.body);
+    print(response.body);
+    final challengeString = json['challengeString'] as String;
+    final encryptedString = json['encryptedString'] as String;
+    try {
+      final decryptedString =
+          await cse.decryptChallengeString(encrypted: encryptedString);
+      print(decryptedString);
+      return decryptedString == challengeString;
+    } catch (e) {
+      return false;
+    }
+  }
+
   Future<void> _setOwnDEK() async {
     final headers = {
       HttpHeaders.authorizationHeader: await _getAuthHeader(),

--- a/Routine-Machine/lib/api/APIWrapper.dart
+++ b/Routine-Machine/lib/api/APIWrapper.dart
@@ -38,6 +38,15 @@ class APIWrapper {
     return 'Bearer $authToken';
   }
 
+  Future<void> overrideKeyPair({String privateKey, String publicKey}) async {
+    if (privateKey != null) {
+      await cse.setPrivateKey(key: privateKey);
+    }
+    if (publicKey != null) {
+      await cse.setPublicKey(key: publicKey);
+    }
+  }
+
   Future<void> createUser(
       {String firstName, String lastName, String userName}) async {
     await cse.refreshOwnerDEK();

--- a/Routine-Machine/lib/api/CSE.dart
+++ b/Routine-Machine/lib/api/CSE.dart
@@ -184,6 +184,11 @@ class CSE {
     return encryptedDEK.decrypt(usingPrivateKey: privateKey.toString());
   }
 
+  Future<String> decryptChallengeString({String encrypted}) async {
+    final privateKey = await getPrivateKey();
+    return privateKey.decrypt(encrypted);
+  }
+
   Future<AESKey> _generateDEK() async {
     final cryptKey = Steel.CryptKey();
     final dek = cryptKey.genFortuna(len: 32);


### PR DESCRIPTION
A working implementation of `Future<bool> APIWrapper#validateDevicePrivateKey`.
I tested this on a local server and it seems to work correctly but further testing won't hurt (although it's becoming pretty painful to get a test working now).

Also implements `Future<void> APIWrapper#overrideKeyPair` which can take in a privateKey, publicKey, or both to override in storage. This can already be done by accessing `APIWrapper().cse.setPrivateKey` directly, but this method should make it cleaner since originally the cse member was meant to be private.

